### PR TITLE
Rake task to clean up compose directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'rake'

--- a/compose/Rakefile
+++ b/compose/Rakefile
@@ -1,0 +1,16 @@
+require 'yaml'
+require 'fileutils'
+
+desc 'Remove local Docker volume directories for stack recreation'
+task :cleanup do
+  compose_dir = File.expand_path(File.dirname(__FILE__))
+  compose_hash = YAML.load_file("#{compose_dir}/docker-compose.yml")
+  services = compose_hash['services'].keys
+
+  services.each do |service|
+    STDOUT.puts "Removing #{service}'s volume directory"
+    path_removed = FileUtils.rm_rf("#{compose_dir}/#{service}")
+    puts "Removed: #{path_removed.first}"
+    puts
+  end
+end


### PR DESCRIPTION
The compose demo maintains local directories backing docker "volumes" after
the env is shut down. This is usually helpful, but not when you want to
test rebuilding the stack from scratch.
