### PR TITLE
fixed the service name to match the directory, rakefile should work now

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     #links:
     #  - puppetdb:puppetdb.local
 
-  puppetdbpostgres:
+  puppetdb-postgres:
     container_name: postgres
     image: puppet/puppetdb-postgres
     environment:


### PR DESCRIPTION
Basically when using the service name for the rakefile, you'll need to make sure the directory is named the same, which in our case it wasn't.

`Removed: /mnt/builds/puppet-docker-compose/compose/puppetdb-postgres`